### PR TITLE
Stop the publish github action from running on main branch

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,7 +1,10 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
-on: push
+on:
+  push:
+    branches-ignore:
+      - main
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
The pipeline appears to be breaking with a file already exists error when a pull request gets merged to the main branch.
This change ignores items that are pushed to main branch.

Another solution to this problem would be to only run these actions when a pull request is merged instead of on push.
The alternative approach can be found here: https://github.com/JBSinc/boston-logger/pull/5