### PR TITLE
Fix github action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,8 +5,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches-ignore:
-      - main
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
`on push ignore-branch` causes an action to fire for every branch that is not included in that branch.

This change removes `on push ignore-branch` and keeps `on push tag` ensuring the release action only runs when tagged.

This was tested on my forks github actions and can confirm it only runs when I trigger a git tag 
However, I do not have the setup to get that action to pass, there is an error.
```
ERROR    HTTPError: 403 Forbidden from https://test.pypi.org/legacy/            
         Invalid or non-existent authentication information.
```

But this should work on your repository that has the correct permissions.